### PR TITLE
Add Nginx proxy 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**/Dockerfile
+**/.dockerignore
+**/id_hmac_pub.key
+**/bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build Docker Image FORMS
         run: |
           cd ${{ env.WORKING_DIRECTORY_FORMS }}
-          docker image build -t ${{ env.DOCKER_PROJECT_NAME_FORMS }} .
+          docker image build -f Dockerfile.prod -t ${{ env.DOCKER_PROJECT_NAME_FORMS }} .
         working-directory: ${{env.working-directory}}
         env:
           DENO_ENV: CI

--- a/.vscode/workspace.code-workspace
+++ b/.vscode/workspace.code-workspace
@@ -11,7 +11,12 @@
         {
             "name": "GENERAL",
             "path": "..",
+        },
+        {
+            "name": "PROXY",
+            "path": "../nginx",
         }
+
     ],
     // "settings": {
     //     "deno.enable": true,

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,4 +1,4 @@
 Dockerfile
 .dockerignore
 id_hmac_pub.key
-bundle
+**/bundle

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
   forms:
     build:
       context: ./forms
-      dockerfile: ./Dockerfile
+      dockerfile: ./Dockerfile.dev
     container_name: token-auth-forms
     
     volumes:
@@ -60,6 +60,19 @@ services:
       - database
     env_file:
       - '.env'      
+
+  nginx:
+    image: nginx:stable-alpine
+    ports:
+      - '8080:80'
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - forms
+      - api
+    networks:
+      - forms
+      - backend
 
 volumes:
   mongodb_api:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,80 @@
+version: '3.8'
+
+services:
+
+  api:
+    build:
+      context: ./api
+      dockerfile: ./Dockerfile
+      args:
+        DENO_VERSION: ${DENO_VERSION-1.17.1}
+        DENO_ENV: ${DENO_ENV-development}
+    container_name: token-auth-server
+    volumes:
+      - '${PWD}/api:/api'
+    depends_on:
+      - api_mongo
+      - api_redis
+    # ports:
+    #   - "3001:3001"
+    networks:
+      - backend
+      - database
+    env_file:
+      - '.env'      
+
+  forms:
+    build:
+      context: ./forms
+      dockerfile: ./Dockerfile.prod
+    container_name: token-auth-forms
+    depends_on:
+      - api
+    ports:
+      - "3002:3002"
+    networks:
+      - forms
+      - backend
+    env_file:
+      - '.env'
+
+  api_redis:
+    image: redis:latest
+    container_name: api_redis
+    ports: 
+      - "6379:6379"
+    networks:
+      - backend
+
+  api_mongo:
+    image: mongo:latest
+    container_name: api_mongo
+    volumes:
+      - mongodb_api:/data/db
+    ports:
+      - '27017:27017'
+    networks:
+      - database
+    env_file:
+      - '.env'      
+
+  nginx:
+    image: nginx:stable-alpine
+    ports:
+      - '8080:80'
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - forms
+      - api
+    networks:
+      - forms
+      - backend
+
+volumes:
+  mongodb_api:
+
+networks:
+  forms:
+  backend:  
+  database:

--- a/forms/.dockerignore
+++ b/forms/.dockerignore
@@ -1,4 +1,5 @@
 .dockerignore
 .git
-node_modules
+**/dist
+**/node_modules
 

--- a/forms/Dockerfile.dev
+++ b/forms/Dockerfile.dev
@@ -3,10 +3,7 @@ FROM node:16-alpine3.12
 RUN mkdir /app
 WORKDIR /app
 
-#RUN npm install -g nodemon
-
 COPY package.json package.json
-#RUN npm install && mv node_modules /node_modules
 RUN yarn install && mv node_modules /node_modules
 
 COPY . .

--- a/forms/Dockerfile.prod
+++ b/forms/Dockerfile.prod
@@ -1,0 +1,20 @@
+FROM node:16-alpine3.12 as build-stage
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY package*.json ./
+RUN yarn install 
+
+COPY ./ .
+
+RUN yarn build
+
+FROM nginx:stable-alpine as production-stage
+RUN mkdir /app
+COPY --from=build-stage /app/dist /app
+COPY /nginx/nginx.conf /etc/nginx/nginx.conf
+
+
+EXPOSE 3002
+CMD ["nginx", "-g", "daemon off;"]

--- a/forms/nginx/nginx.conf
+++ b/forms/nginx/nginx.conf
@@ -1,0 +1,30 @@
+user  nginx;
+worker_processes  1;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+events {
+  worker_connections  1024;
+}
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log  /var/log/nginx/access.log  main;
+  sendfile        on;
+  keepalive_timeout  65;
+  server {
+    listen       0.0.0.0:3002;
+    server_name  forms;
+    location / {
+      root   /app;
+      index  index.html;
+      try_files $uri $uri/ /index.html;
+    }
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+      root   /usr/share/nginx/html;
+    }
+  }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,24 @@
+server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+
+        server_name token-auth-server;
+
+        location / {
+                proxy_http_version 1.1;
+                proxy_cache_bypass $http_upgrade;
+
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection 'upgrade';
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                proxy_pass http://forms:3002/;
+        }
+        
+        location /api/ {
+                proxy_pass http://api:3001/api/;
+        }
+}


### PR DESCRIPTION
Add nginx so only one address:port is needed to access both api and forms

- Add a docker compose file for both development and production
   - development will map volume drives so watchfile works while developing
   - production will use production builds of the different projects

Add production build to forms …

- add `nginx` static file server
- add a Dockerfile for dev and prod
   - dev still serves the application for helping with development
   - prod will build the vue product and server the static built files

Add nginx config file and workspace name